### PR TITLE
Copied the google tag manager code in place and make the id an env setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,5 @@ TZ='America/New_York'
 
 EVENTS_API_DOMAIN='https://events.openupstate.org'
 ORGS_API_DOMAIN='https://data.openupstate.org'
+
+GOOGLE_TAG_MANAGER=

--- a/config/services.php
+++ b/config/services.php
@@ -37,4 +37,10 @@ return [
         'secret' => env('STRIPE_SECRET'),
     ],
 
+    'google' => [
+        'tagmanager' => [
+            'id' => env('GOOGLE_TAG_MANAGER')
+        ],
+    ],
+
 ];

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -51,6 +51,18 @@
     <script src='{{url('vendors/fullcalendar/packages/core/main.min.js')}}'></script>
     <script src='{{url('vendors/fullcalendar/packages/daygrid/main.js')}}'></script>
 
+    @if(config('services.google.tagmanager.id'))
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{config('services.google.tagmanager.id')}}"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', '{{config('services.google.tagmanager.id')}}');
+    </script>
+    @endif
+
     @yield('head')
 </head>
 <body>


### PR DESCRIPTION
https://github.com/codeforgreenville/hackgreenville-com/issues/23

Just make sure to add 

`GOOGLE_TAG_MANAGER="UA-154722329-1"`

to the .env file in the root of the project.

Without that setting the tag manager code won't show up. I did this so when people work on it locally it won't affect the stats of the site.