### PR TITLE
Add more detail to events listing on homepage

### DIFF
--- a/app/Http/Controllers/Api/HomepageController.php
+++ b/app/Http/Controllers/Api/HomepageController.php
@@ -13,7 +13,7 @@ class HomepageController extends Controller
         // we only need a few events for the homepage
         return Event::getActive()
             ->take(5)
-            ->select(['event_name', 'description', 'active_at', 'expire_at'])
+            ->select(['event_name', 'group_name', 'description', 'active_at', 'expire_at'])
             ->get();
     }
 }

--- a/app/Http/Controllers/Api/HomepageController.php
+++ b/app/Http/Controllers/Api/HomepageController.php
@@ -13,7 +13,7 @@ class HomepageController extends Controller
         // we only need a few events for the homepage
         return Event::getActive()
             ->take(5)
-            ->select(['event_name', 'group_name', 'description', 'active_at', 'expire_at'])
+            ->select(['event_name', 'group_name', 'description', 'active_at', 'expire_at', 'uri'])
             ->get();
     }
 }

--- a/resources/js/components/TimelineComponent.vue
+++ b/resources/js/components/TimelineComponent.vue
@@ -15,7 +15,7 @@
                 <div class="timeline-panel">
                     <div class="timeline-heading">
                         <h4 class="timeline-title">{{event.title}}</h4>
-                        <p class="timeline-subtitle h5">{{event.group_name}}</p>
+                        <p class="timeline-subtitle h6">{{event.group_name}}</p>
                         <p><small :title="event.active_at" class="text-muted"><i class="fa fa-calendar"/> {{event.active_at_ftm}}</small></p>
                     </div>
                     <div class="timeline-body">
@@ -60,7 +60,7 @@
                 this.events = events;
                 this.loading--;
             },
-            showMore({title, group_name, active_at_ftm, active_at, description}) {
+            showMore({title, group_name, active_at_ftm, active_at, description, uri}) {
                 const datetime_format = 'MM/DD hh:mm A';
                 const desc
                     = `<div class="text-center">`
@@ -72,14 +72,23 @@
                     + description
                     + "</div>";
 
-                swal.fire({
+                let conf = {
                     title: title,
                     html: desc,
                     type: 'info',
                     showCancelButton: false,
                     customClass: 'swal-wide',
-                    showCloseButton: false,
-                })
+                    showCloseButton: true,
+                };
+
+                if(uri) {
+                    conf.confirmButtonText = "Visit Event Page";
+                    conf.preConfirm = () => {
+                        window.open(uri, "_blank");
+                    };
+                };
+
+                swal.fire(conf);
             }
         },
         async mounted() {

--- a/resources/js/components/TimelineComponent.vue
+++ b/resources/js/components/TimelineComponent.vue
@@ -15,6 +15,7 @@
                 <div class="timeline-panel">
                     <div class="timeline-heading">
                         <h4 class="timeline-title">{{event.title}}</h4>
+                        <h5 class="timeline-subtitle">((event.group_name))</h5>
                         <p><small :title="event.active_at" class="text-muted"><i class="fa fa-calendar"/> {{event.active_at_ftm}}</small></p>
                     </div>
                     <div class="timeline-body">
@@ -62,7 +63,10 @@
             showMore({title, active_at_ftm, active_at, description}) {
                 const datetime_format = 'MM/DD hh:mm A';
                 const desc
-                    = `<div class="text-left">`
+                    = `<div class="text-center">`
+                    + `<h3>Hosted by ((group))</h3>`
+                    + `</div>`
+                    + `<div class="text-left">`
                     + `<strong>Starts:</strong> ${active_at_ftm} on ${moment(active_at).format(datetime_format)}`
                     + "<br /><br />"
                     + description

--- a/resources/js/components/TimelineComponent.vue
+++ b/resources/js/components/TimelineComponent.vue
@@ -15,7 +15,7 @@
                 <div class="timeline-panel">
                     <div class="timeline-heading">
                         <h4 class="timeline-title">{{event.title}}</h4>
-                        <h5 class="timeline-subtitle">((event.group_name))</h5>
+                        <p class="timeline-subtitle h5">{{event.group_name}}</p>
                         <p><small :title="event.active_at" class="text-muted"><i class="fa fa-calendar"/> {{event.active_at_ftm}}</small></p>
                     </div>
                     <div class="timeline-body">
@@ -60,11 +60,11 @@
                 this.events = events;
                 this.loading--;
             },
-            showMore({title, active_at_ftm, active_at, description}) {
+            showMore({title, group_name, active_at_ftm, active_at, description}) {
                 const datetime_format = 'MM/DD hh:mm A';
                 const desc
                     = `<div class="text-center">`
-                    + `<h3>Hosted by ((group))</h3>`
+                    + `<p class="h4">Hosted by ${group_name}</p>`
                     + `</div>`
                     + `<div class="text-left">`
                     + `<strong>Starts:</strong> ${active_at_ftm} on ${moment(active_at).format(datetime_format)}`


### PR DESCRIPTION
Refers to codeforgreenville/hackgreenville-com#58
___

# Issue description
_@allella_ 
> The screenshot here shows an example of the issue.
> 
> It's unclear which group is hosting the meetups and there's no way to see more details that clarify the issue.
> 
> Perhaps we can list the organization's name instead of the event name. Then, in the pop-up we have the event title, a link to the event homepage, or some such?
> 
> As far as I'm concerned, it's fine if people leave the website, so we don't need to worry making it easy for people to click away to the actual event.
> 
> ![image](https://user-images.githubusercontent.com/1777776/74690226-3f830f80-51ac-11ea-8725-b9c92b2bc3cf.png)

## Requirements
- Some form of reference to hosting group in both initial listing _and_ popup
- Link in description to off-site event page

## Options for showing hosting group
1. In events list, show host as event title (taken from above description)
2. In events list, show host under event name