### PR TITLE
Add SQLite PHP extensions to the Composer.json require-dev.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "spatie/laravel-google-calendar": "^2.5"
   },
   "require-dev": {
-    "ext-sqlite3": "^7.4",
+    "ext-sqlite3": "^7.2",
+    "ext-pdo_sqlite": "^7.2",
     "barryvdh/laravel-debugbar": "^3.2",
     "barryvdh/laravel-ide-helper": "^2.6",
     "filp/whoops": "^2.7",


### PR DESCRIPTION
As mentioned in #70, the composer.json needs:

- two PHP extensions in require-dev
- the version required should be ^7.2 since PHP 7.2.5 is the current minimum version of PHP.

Closes #70 