### PR TITLE
Update the contribute links in the footer of the Events and Orgs pages to allow a Suggestions link

### DIFF
--- a/resources/views/events/index.blade.php
+++ b/resources/views/events/index.blade.php
@@ -53,9 +53,12 @@
             @endforeach
         </ul>
 
-        <p><small>This data is sourced from <a href="https://data.openupstate.org">a community-curated REST API</a>. To contribute or use the API connect with <a href="https://codeforgreenville.org">Code For
-                    Greenville.</a></small>
-        </p>
+        <ul>
+       	    <li>This data is sourced from <a href="https://data.openupstate.org" target="_blank">a community-curated REST API</a>.</li>
+            <li>To contribute to this project, please connect with <a href="https://codeforgreenville.org" target="_blank">Code For Greenville.</a></li>
+            <li>To suggest an addition or update to the data, please submit a <a href="https://data.openupstate.org/contact/suggestions">suggestion</a>.</li>
+        </ul>
+
     </div>
 @endsection
 

--- a/resources/views/orgs/index.blade.php
+++ b/resources/views/orgs/index.blade.php
@@ -54,12 +54,11 @@
             </div>
         </div>
 
-        <p>
-            <small>
-                This data is sourced from <a href="https://data.openupstate.org" target="_blank">a community-curated REST API</a>.
-                To contribute or use the API connect with <a href="https://codeforgreenville.org" target="_blank">Code For Greenville.</a>
-            </small>
-        </p>
+        <ul>
+            <li>This data is sourced from <a href="https://data.openupstate.org" target="_blank">a community-curated REST API</a>.</li>
+            <li>To contribute to this project, please connect with <a href="https://codeforgreenville.org" target="_blank">Code For Greenville.</a></li>
+            <li>To suggest an addition or update to the data, please submit a <a href="https://data.openupstate.org/contact/suggestions">suggestion</a>.</li>
+        </ul>
 
     </div>
 @endsection


### PR DESCRIPTION
We have a new form on the data site to allow for suggestions.  

This adds a link to the bottom of the Orgs and Events pages to allow for suggestions.